### PR TITLE
use VOCABULARY instead of ruleNames in lexer test

### DIFF
--- a/src/test/kotlin/me/tomassetti/sandy/SandyLexerTest.kt
+++ b/src/test/kotlin/me/tomassetti/sandy/SandyLexerTest.kt
@@ -17,7 +17,7 @@ class SandyLexerTest {
            val t = lexer.nextToken()
             when (t.type) {
                 -1 -> tokens.add("EOF")
-                else -> if (t.type != SandyLexer.WS) tokens.add(lexer.ruleNames[t.type - 1])
+                else -> if (t.type != SandyLexer.WS) tokens.add(SandyLexer.VOCABULARY.getSymbolicName(t.type))
             }
         } while (t.type != -1)
         return tokens


### PR DESCRIPTION
Probably should use `VOCABULARY` instead of `ruleNames` in lexer test because it may not work in some cases (wrong name order). I tried it with another language grammar in my project and only `VOCABULARY` worked correctly.