### PR TITLE
Correct Token.endPoint() for $reciever of <EOF>

### DIFF
--- a/src/main/kotlin/me/tomassetti/sandy/ast/Mapping.kt
+++ b/src/main/kotlin/me/tomassetti/sandy/ast/Mapping.kt
@@ -12,7 +12,7 @@ fun SandyFileContext.toAst(considerPosition: Boolean = false) : SandyFile = Sand
 
 fun Token.startPoint() = Point(line, charPositionInLine)
 
-fun Token.endPoint() = Point(line, charPositionInLine + text.length)
+fun Token.endPoint() = Point(line, charPositionInLine + (if (type == EOF) 0 else text.length))
 
 fun ParserRuleContext.toPosition(considerPosition: Boolean) : Position? {
     return if (considerPosition) Position(start.startPoint(), stop.endPoint()) else null


### PR DESCRIPTION
When the ANTLR Token is an <EOF>, [`#getText()` returns `"<EOF>"`](https://github.com/antlr/antlr4/blob/a6e7a72ac767d73e6f760750b53b13e2e89d7261/runtime/Java/src/org/antlr/v4/runtime/CommonToken.java#L173). So that `Token.endPoint()` calculates the correct end position when the token is an <EOF>, we need to make sure that the length of the EOF token is counted as 0 and not 5.