### PR TITLE
README Fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,20 +1,39 @@
 # LangSandbox
 
-This project is used to illustrate how to build a programming language. The code present here is discussed in a series of articles.
+This project is used to illustrate how to build a programming language.
+The code present here is discussed in a series of articles.
 
-From these series of tutorials I derived a [book on creating languages](https://tomassetti.me/create-languages).
+From these series of tutorials I derived a [book on creating languages].
 
+You may be interested in the companion project ([Kanvas]) where we show how to build an editor for your language.
 
-You may be interested in the companion project ([Kanvas](https://github.com/ftomassetti/kanvas)) where we show how to build an editor for your language.
-
-1. [Define the lexer](https://tomassetti.me/getting-started-with-antlr-building-a-simple-expression-language/)
-2. [Define the parser](https://tomassetti.me/building-and-testing-a-parser-with-antlr-and-kotlin/)
-3. [Build an editor with syntax highlighting]() (the code for this part is in [this project](https://github.com/ftomassetti/kanvas))
-4. [Build an editor with autocompletion]() (the code for this part is in [this project](https://github.com/ftomassetti/kanvas))
-5. [Map the parse tree to the abstract syntax tree](https://tomassetti.me/parse-tree-abstract-syntax-tree/)
-6. [Transform the abstract syntax tree](https://tomassetti.me/model-to-model-transformations/)
-7. [Validate the abstract syntax tree](https://tomassetti.me/building-compiler-language-validation/)
-8. [Generate bytecode](https://tomassetti.me/generating-bytecode/)
+1. [Define the lexer]
+2. [Define the parser]
+3. [Build an editor with syntax highlighting]  (the code for this part is in [this project][Kanvas])
+4. [Build an editor with autocompletion]  (the code for this part is in [this project][Kanvas])
+5. [Map the parse tree to the abstract syntax tree]
+6. [Transform the abstract syntax tree]
+7. [Validate the abstract syntax tree]
+8. [Generate bytecode]
 
 I hope you enjoy and please let me know if you have issues, ideas, comments or any sort of feedback!
 
+<!-----------------------------------------------------------------------------
+                               REFERENCE LINKS
+------------------------------------------------------------------------------>
+
+[Kanvas]: https://github.com/ftomassetti/kanvas "Visit the Kanvas repository on GitHub"
+[book on creating languages]: https://tomassetti.me/create-languages "'How to Create Pragmatic, Lightweight Languages' by Federico Tomassetti"
+
+<!-- tutorials -->
+
+[Define the lexer]: https://tomassetti.me/getting-started-with-antlr-building-a-simple-expression-language/ "Read the tutorial on tomassetti.me"
+[Define the parser]: https://tomassetti.me/building-and-testing-a-parser-with-antlr-and-kotlin/ "Read the tutorial on tomassetti.me"
+[Build an editor with syntax highlighting]: https://tomassetti.me/how-to-create-an-editor-with-syntax-highlighting-dsl/ "Read the tutorial on tomassetti.me"
+[Build an editor with autocompletion]: https://tomassetti.me/autocompletion-editor-antlr/ "Read the tutorial on tomassetti.me"
+[Map the parse tree to the abstract syntax tree]: https://tomassetti.me/parse-tree-abstract-syntax-tree/ "Read the tutorial on tomassetti.me"
+[Transform the abstract syntax tree]: https://tomassetti.me/model-to-model-transformations/ "Read the tutorial on tomassetti.me"
+[Validate the abstract syntax tree]: https://tomassetti.me/building-compiler-language-validation/ "Read the tutorial on tomassetti.me"
+[Generate bytecode]: https://tomassetti.me/generating-bytecode/ "Read the tutorial on tomassetti.me"
+
+<!-- EOF -->


### PR DESCRIPTION
- Fix some broken links pointing to the tutorials (links 3 and 4).
- Convert inline-links to reference-links to improve source readability and links maintainance via reusable labels which are defined only once (DRY approach vs WET).
- Move all reference links definitions at the end of the document, to provide a better editing experience and to improve readability of the raw source in shells.
- Add title-text to reference-links to show more info on hovering and to imrpove search engine indexing (SEO).
- Split text one-line-per-sentence, to provide better commits diffs when contents are changed, as well as to improve the editing experience.
